### PR TITLE
Fix SiteInfo class PSR-4 Loading

### DIFF
--- a/src/SiteInfo.php
+++ b/src/SiteInfo.php
@@ -2,9 +2,8 @@
 
 namespace TalentLMS;
 
-class Siteinfo extends ApiResource
+class SiteInfo extends ApiResource
 {
-
     public static function get()
     {
         $class = get_class();


### PR DESCRIPTION
## Summary of Changes

Fixes the capitalization of the class `SiteInfo` to load correctly for PSR-4 autoloading.